### PR TITLE
Hash large files in chunks to avoid exceeding memory

### DIFF
--- a/scraping_utils.py
+++ b/scraping_utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from os import listdir, system, name
-from os.path import join, isfile, isdir
+from os.path import join, isfile, isdir, commonpath
 from sys import stdout
 from threading import Thread, enumerate
 import hashlib
@@ -234,7 +234,8 @@ def multithread_download_urls_special(Dtsc, urls, pics_dst, vids_dst, algo=hashl
         return hashes
         
     # Print the initial status box
-    msg = f'Successfully downloaded media from 0/{len(urls)} URLs'
+    dst = commonpath([pics_dst, vids_dst])
+    msg = f'Successfully downloaded media from 0/{len(urls)} URLs to {dst}'
     print(f'.{"="*(len(msg)+2)}.')
     print(f'| {msg} |')
     print(f'\'{"="*(len(msg)+2)}\'')

--- a/scraping_utils.py
+++ b/scraping_utils.py
@@ -42,6 +42,8 @@ class DownloadThread(Thread):
         self.hashes = hashes
         self.algo = algo
         self.status = self.STANDBY
+        self.total_size = 1
+        self.downloaded = 0
         
     # Perform downloading until successful or deemed impossible
     def run(self):
@@ -51,6 +53,8 @@ class DownloadThread(Thread):
             while(self.status == self.STANDBY):
                 self.status = self.DOWNLOADING
                 res = requests.get(self.url)
+                self.total_size = int(res.headers.get("content-length", 0))
+                self.downloaded = len(res.content)
                 if(res.status_code == TOO_MANY_REQUESTS):
                     self.status = self.STANDBY
                     time.sleep(THROTTLE_TIME)
@@ -92,7 +96,7 @@ class DownloadThread(Thread):
         elif(self.status == self.FINISHED): status_char = ' ✓ '
         elif(self.status == self.ERROR): status_char = ' E '
         else: status_char = ' ? '
-        stdout.write(f'[{status_char}] {self.url}\n')
+        stdout.write(f'[{status_char} - {self.downloaded / self.total_size:6.1%}] {self.url}\n')
 
 
 """

--- a/scraping_utils.py
+++ b/scraping_utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from os import listdir, system, name
 from os.path import join, isfile, isdir
 from sys import stdout
@@ -133,7 +135,7 @@ def compute_file_hashes(dir, exts=None, algo=hashlib.md5, hashes={}, short=False
             stdout.write(f'[compute_file_hashes] INFO: Hashing ({full_name})... ')
             stdout.flush()
             with open(full_name, 'rb') as file_in:
-                file_hash = algo
+                file_hash = algo()
                 if short:
                     chunk = file_in.read(1024 * 64)
                     file_hash.update(chunk)

--- a/scraping_utils.py
+++ b/scraping_utils.py
@@ -133,15 +133,17 @@ def compute_file_hashes(dir, exts=None, algo=hashlib.md5, hashes={}, short=False
             stdout.write(f'[compute_file_hashes] INFO: Hashing ({full_name})... ')
             stdout.flush()
             with open(full_name, 'rb') as file_in:
+                file_hash = algo
                 if short:
-                    file_hash = algo(file_in.read(1024 * 64).hexdigest()
+                    chunk = file_in.read(1024 * 64)
+                    file_hash.update(chunk)
                 else:
                     while True:
-                        chunk = file_in.read(1024 * 1024 * 2)
+                        chunk = file_in.read(1024 * 1024 * 128)
                         if not chunk:
                             break
-                        algo.update(chunk)
-                    file_hash = algo.hexdigest()
+                        file_hash.update(chunk)
+                file_hash = file_hash.hexdigest()
 
             if(file_hash not in hashes):
                 hashes[file_hash] = full_name

--- a/scraping_utils.py
+++ b/scraping_utils.py
@@ -133,8 +133,15 @@ def compute_file_hashes(dir, exts=None, algo=hashlib.md5, hashes={}, short=False
             stdout.write(f'[compute_file_hashes] INFO: Hashing ({full_name})... ')
             stdout.flush()
             with open(full_name, 'rb') as file_in:
-                file_bytes = short and file_in.read(1024 * 64) or file_in.read()
-                file_hash = algo(file_bytes).hexdigest()
+                if short:
+                    file_hash = algo(file_in.read(1024 * 64).hexdigest()
+                else:
+                    while True:
+                        chunk = file_in.read(1024 * 1024 * 2)
+                        if not chunk:
+                            break
+                        algo.update(chunk)
+                    file_hash = algo.hexdigest()
 
             if(file_hash not in hashes):
                 hashes[file_hash] = full_name

--- a/scraping_utils.py
+++ b/scraping_utils.py
@@ -269,7 +269,7 @@ def multithread_download_urls_special(Dtsc, urls, pics_dst, vids_dst, algo=hashl
         
         # Print the status box
         howManyCompleted = max(0, pos-MAX_THREADS)
-        msg = f'Successfully downloaded media from {howManyCompleted}/{len(urls)} URLs'
+        msg = f'Successfully downloaded media from {howManyCompleted}/{len(urls)} URLs to {dst}'
         print(f'.{"="*(len(msg)+2)}.')
         print(f'| {msg} |')
         print(f'\'{"="*(len(msg)+2)}\'')
@@ -290,7 +290,7 @@ def multithread_download_urls_special(Dtsc, urls, pics_dst, vids_dst, algo=hashl
         for _ in range(0, prevThreadCnt+3): stdout.write('\033[F')
         
         # Print the status box
-        msg = f'Successfully downloaded media from {pos-len(remaining)}/{len(urls)} URLs'
+        msg = f'Successfully downloaded media from {pos-len(remaining)}/{len(urls)} URLs to {dst}'
         print(f'.{"="*(len(msg)+2)}.')
         print(f'| {msg} |')
         print(f'\'{"="*(len(msg)+2)}\'')
@@ -308,7 +308,7 @@ def multithread_download_urls_special(Dtsc, urls, pics_dst, vids_dst, algo=hashl
     for _ in range(0, len(download_threads)+3): stdout.write('\033[F')
     
     # Print the final status box
-    msg = f'Successfully downloaded media from {pos-len(remaining)}/{len(urls)} URLs'
+    msg = f'Successfully downloaded media from {pos-len(remaining)}/{len(urls)} URLs to {dst}'
     print(f'.{"="*(len(msg)+2)}.')
     print(f'| {msg} |')
     print(f'\'{"="*(len(msg)+2)}\'')


### PR DESCRIPTION
Previously large files were read into memory completely before hashing them. Depending on the available memory this can cause issues with large files. With these changes, the files is iterated over in 128MB chunks and consecutively hashed